### PR TITLE
Prevent 'Invalid argument supplied for foreach()'

### DIFF
--- a/FtpClient.php
+++ b/FtpClient.php
@@ -659,6 +659,12 @@ class FtpClient implements \Countable
         }
 
         $list = $this->ftp->rawlist($directory);
+        if (false === $list) {
+            // $list can be false, convert to empty array
+            $list = [];
+        }
+
+        
         $items = [];
         if (false == $recursive) {
             foreach ($list as $path => $item) {

--- a/FtpClient.php
+++ b/FtpClient.php
@@ -663,7 +663,6 @@ class FtpClient implements \Countable
             // $list can be false, convert to empty array
             $list = [];
         }
-
         
         $items = [];
         if (false == $recursive) {


### PR DESCRIPTION
The Exception 'Invalid argument supplied for foreach()' was thrown if $this->ftp->rawlist($directory) returned false;
White this fix, $list is converted into an empty array if false was returned.