### PR TITLE
restore original mentions

### DIFF
--- a/FtpClient.php
+++ b/FtpClient.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * This file is part of the `nicolab/php-ftp-client` package.
+ *
+ * (c) Nicolas Tallefourtane <dev@nicolab.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Nicolas Tallefourtane https://nicolab.net
+ */
 
 namespace yii2mod\ftp;
 
@@ -663,7 +673,7 @@ class FtpClient implements \Countable
             // $list can be false, convert to empty array
             $list = [];
         }
-        
+
         $items = [];
         if (false == $recursive) {
             foreach ($list as $path => $item) {

--- a/FtpException.php
+++ b/FtpException.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * This file is part of the `nicolab/php-ftp-client` package.
+ *
+ * (c) Nicolas Tallefourtane <dev@nicolab.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Nicolas Tallefourtane https://nicolab.net
+ */
 
 namespace yii2mod\ftp;
 

--- a/FtpWrapper.php
+++ b/FtpWrapper.php
@@ -1,4 +1,14 @@
 <?php
+/*
+ * This file is part of the `nicolab/php-ftp-client` package.
+ *
+ * (c) Nicolas Tallefourtane <dev@nicolab.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright Nicolas Tallefourtane https://nicolab.net
+ */
 
 namespace yii2mod\ftp;
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,22 @@
-Copyright (c) 2015 yii2mod
+The MIT License (MIT)
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2014 Nicolas Tallefourtane dev@nicolab.net
 
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 
 [![Latest Stable Version](https://poser.pugx.org/yii2mod/yii2-ftp/v/stable)](https://packagist.org/packages/yii2mod/yii2-ftp) [![Total Downloads](https://poser.pugx.org/yii2mod/yii2-ftp/downloads)](https://packagist.org/packages/yii2mod/yii2-ftp) [![License](https://poser.pugx.org/yii2mod/yii2-ftp/license)](https://packagist.org/packages/yii2mod/yii2-ftp)
 
+> yii2-ftp is a fork of [Nicolab/php-ftp-client](https://github.com/Nicolab/php-ftp-client) v1.2.0
+
 Installation
 ------------
 
-The preferred way to install this extension is through [composer](http://getcomposer.org/download/). 
+The preferred way to install this extension is through [composer](http://getcomposer.org/download/).
 
 Either run
 


### PR DESCRIPTION
Please, be Fair-play...
Your project is a fork of https://github.com/Nicolab/php-ftp-client, you dont have right to remove the initial author name and put yours in the place as if you are the author of this. So I ask you to put a gain the name of the original author.

Please, append your name in the license if you want but do not delete the original author and the mention of the fork.

